### PR TITLE
put me view back on

### DIFF
--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -163,7 +163,7 @@ update msg model =
                 Just me ->
                     case newRoute of
                         GoLogOut ->
-                            ( { model | auth = { auth | state = Auth0.LoggedOut }, me = Nothing }, model.auth.logOut () )
+                            ( { model | auth = { auth | state = Auth0.LoggedOut }, me = Nothing, route = GoEvents Nothing }, model.auth.logOut () )
 
                         GoEvents eventId ->
                             goEventUpdate eventId

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -10,6 +10,7 @@ import Views.Chat as Chat
 import Views.Chats as Chats
 import Views.CreateEvent as CreateEvent
 import Views.EditMe as EditMe
+import Views.Me as Me
 import Views.Event as Event
 import Views.Events as Events
 import Views.Nav as Nav exposing (..)
@@ -72,6 +73,9 @@ page model =
 
         GoPool pool ->
             [ Pool.view pool model ]
+
+        GoMe me -> 
+            [ Me.view me ]
 
         GoEditMe ->
             [ EditMe.view model ]

--- a/src/elm/Views/Me.elm
+++ b/src/elm/Views/Me.elm
@@ -7,12 +7,8 @@ import Html.Events exposing (..)
 import Types exposing (..)
 
 
-view : Model -> Html Msg
-view model =
-    let
-        me =
-            model.me
-    in
+view : Me -> Html Msg
+view me =
     section [ class "w-100 mw7-l overflow-auto shadow-2-l" ]
         [ div [ class "flex h5 ph3 ph4-m ph5-l pt6 items-center" ]
             [ meAvi
@@ -83,7 +79,7 @@ meToolsView =
             [ div [ Assets.feather "edit", class "contain bg-center grow pt3 pb2 pl3 pr2" ] []
             , div [ class "pa2" ] [ text "edit" ]
             ]
-        , div [ class "animated bounceIn pointer hover-bg-black-50 br-2 pa3 flex items-center", onClick (Types.RouteTo GoAuth) ]
+        , div [ class "animated bounceIn pointer hover-bg-black-50 br-2 pa3 flex items-center", onClick (Types.RouteTo GoLogOut) ]
             [ div [ Assets.feather "log-out", class "contain bg-center grow pt3 pb2 pl3 pr2" ] []
             , div [ class "pa2" ] [ text "log out" ]
             ]


### PR DESCRIPTION
put the me view back on so shows on successful login and data retrieval, clear the route back to events when logout 
(Created a record related to my facebook login in GraphCool so I could check that record is retrieved.)